### PR TITLE
Downgrade protobuf

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -622,7 +622,7 @@ Apache Software License
 UNKNOWN
 
 protobuf
-5.28.0
+5.27.4
 3-Clause BSD License
 Copyright 2008 Google Inc.  All rights reserved.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ requires-python = ">=3.10"
 dependencies = [
     "grpcio>=1.65, <2",
     "grpcio-tools>=1.65, <2",
-    "protobuf>=5.27, <6",
-    "types-protobuf>=5.27, <6",
+    "protobuf>=5.27, <5.28",
+    "types-protobuf>=5.27, <5.28",
     "uvloop>=0.20, <1"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 grpcio==1.66.1
 grpcio-tools==1.66.1
-protobuf==5.28.0
+protobuf==5.27.4
 uvloop==0.20.0
 elasticsearch[async]==8.15.0
 ruff==0.6.3


### PR DESCRIPTION
Got some problems with 5.28 in connectors repo:

```
_______________________________________________________________ ERROR collecting tests/agent/test_protocol.py _______________________________________________________________
.venv/lib/python3.11/site-packages/_pytest/runner.py:341: in from_call
    result: Optional[TResult] = func()
.venv/lib/python3.11/site-packages/_pytest/runner.py:372: in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
.venv/lib/python3.11/site-packages/_pytest/python.py:531: in collect
    self._inject_setup_module_fixture()
.venv/lib/python3.11/site-packages/_pytest/python.py:545: in _inject_setup_module_fixture
    self.obj, ("setUpModule", "setup_module")
.venv/lib/python3.11/site-packages/_pytest/python.py:310: in obj
    self._obj = obj = self._getobj()
.venv/lib/python3.11/site-packages/_pytest/python.py:528: in _getobj
    return self._importtestmodule()
.venv/lib/python3.11/site-packages/_pytest/python.py:617: in _importtestmodule
    mod = import_path(self.path, mode=importmode, root=self.config.rootpath)
.venv/lib/python3.11/site-packages/_pytest/pathlib.py:565: in import_path
    importlib.import_module(module_name)
../../.pyenv/versions/3.11.9/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1204: in _gcd_import
    ???
<frozen importlib._bootstrap>:1176: in _find_and_load
    ???
<frozen importlib._bootstrap>:1147: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:690: in _load_unlocked
    ???
.venv/lib/python3.11/site-packages/_pytest/assertion/rewrite.py:178: in exec_module
    exec(co, module.__dict__)
tests/agent/test_protocol.py:9: in <module>
    from elastic_agent_client.generated import elastic_agent_client_pb2 as proto
.venv/lib/python3.11/site-packages/elastic_agent_client/generated/elastic_agent_client_pb2.py:12: in <module>
    _runtime_version.ValidateProtobufRuntimeVersion(
.venv/lib/python3.11/site-packages/google/protobuf/runtime_version.py:112: in ValidateProtobufRuntimeVersion
    warnings.warn(
E   UserWarning: Protobuf gencode version 5.27.2 is older than the runtime version 5.28.0 at elastic-agent-client.proto. Please avoid checked-in Protobuf gencode that can be obsolete.
```

Looks like we need to stick to 5.27.4 for now!
