### PR TITLE
[Protocol] Detect log level change in checkin action

### DIFF
--- a/elastic_agent_client/service/checkin.py
+++ b/elastic_agent_client/service/checkin.py
@@ -5,6 +5,7 @@
 #
 import asyncio
 import functools
+import logging
 from asyncio import sleep
 
 import elastic_agent_client.generated.elastic_agent_client_pb2 as proto
@@ -67,9 +68,12 @@ class CheckinV2Service(BaseService):
         if self.client.units and self.client.component_idx == checkin.component_idx:
             change_detected = False
             expected_units = [
-                (unit.id, unit.config_state_idx) for unit in checkin.units
+                (unit.id, unit.config_state_idx, unit.log_level)
+                for unit in checkin.units
             ]
-            current_units = [(unit.id, unit.config_idx) for unit in self.client.units]
+            current_units = [
+                (unit.id, unit.config_idx, unit.log_level) for unit in self.client.units
+            ]
             for current_unit in current_units:
                 if current_unit not in expected_units:
                     change_detected = True
@@ -115,7 +119,9 @@ class CheckinV2Service(BaseService):
             if log_level:
                 # Convert the UnitLogLevel to the corresponding Python logging level
                 python_log_level = convert_agent_log_level(log_level)
-                logger.info(f"Updating log level to {python_log_level}")
+                logger.info(
+                    f"Updating log level to {logging.getLevelName(python_log_level)}"
+                )
                 set_logger(log_level=python_log_level)
             else:
                 logger.debug("No log level found for the output unit")

--- a/tests/service/test_checkin.py
+++ b/tests/service/test_checkin.py
@@ -251,6 +251,7 @@ async def test_apply_expected_when_no_change(
         Unit(
             unit_id=checkin_expected.units[0].id,
             config_idx=checkin_expected.units[0].config_state_idx,
+            log_level=checkin_expected.units[0].log_level,
         )
     ]  # same unit
     checkin_service = CheckinV2Service(v2_client, checkin_handler)


### PR DESCRIPTION
### Changes

When changing the log level in Fleet UI I noticed that the `info` log statement from python elastic agent client "updating log level to: " was not present in logs. I tracked this down to the fact that we didn't treat log level change as a "change" according to our checking service manager. 

This PR checks for logging changes in the `apply_expected` in `elastic_agent_client/service/checkin.py`. 

Additionally I'm pretty printing the resulting python log level in `info` logs.

### Verification

Manual test setup:

Toggle between `info`, `debug`, `warn`, `critical` log levels. As expected only `info` and `debug` log level changes are logged (as the log itself is of info level).

<img width="851" alt="Screenshot 2024-09-24 at 12 25 21" src="https://github.com/user-attachments/assets/029a3994-cb27-4dd7-bc99-cd3b9b99a030">

The python service detects this change and restarts as expected
<img width="1677" alt="Screenshot 2024-09-24 at 12 29 29" src="https://github.com/user-attachments/assets/0283b64e-3c02-40d6-acc0-0a21e0862e52">

The python component log level is changed as expected.