### PR TITLE
Rename the ingestion-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo.
-*       @elastic/ingestion-team
+*       @elastic/search-extract-and-transform

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,7 +12,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:ingestion-team
+  owner: group:search-extract-and-transform
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -24,7 +24,7 @@ spec:
       repository: elastic/python-elastic-agent-client
       pipeline_file: ".buildkite/pipeline.yml"
       teams:
-        ingestion-team:
+        search-extract-and-transform:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
### Description
As part of the GitHub teams renaming initiative, it's required to rename the @elastic/ingestion-team to @elastic/search-extract-and-transform.

This PR is dedicated to renaming @elastic/ingestion-team to @elastic/search-extract-and-transform 