### PR TITLE
Add pull-requests.json config

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -1,0 +1,27 @@
+{
+  "jobs": [
+    {
+      "enabled": true,
+      "pipeline_slug": "python-elastic-agent-client",
+      "allow_org_users": true,
+      "allowed_repo_permissions": [
+        "admin",
+        "write"
+      ],
+      "allowed_list": [
+        "dependabot[bot]",
+        "renovate[bot]"
+      ],
+      "build_on_commit": true,
+      "build_on_comment": true,
+      "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
+      "skip_ci_labels": [
+        "skip-ci"
+      ],
+      "skip_ci_on_only_changed": [
+        "\\.md$"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Can't trigger CI for this PR https://github.com/elastic/python-elastic-agent-client/pull/74 ... 

This adds pull requests config according to our internal `buildkite cookbook guide`, it should allow us to trigger CI with `buildkite test this`

Verified that pipeline slug is correct `python-elastic-agent-client`