### PR TITLE
have renovate ignore protobuf

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>elastic/renovate-config"
+  ],
+  "ignoreDeps": [
+    "protobuf",
+    "types-protobuf"
   ]
 }


### PR DESCRIPTION
We've hit this previously: https://github.com/elastic/python-elastic-agent-client/pull/54

This should keep renovate from putting up PRs that try to update protobuf automatically. 