### PR TITLE
Allow publishing packages + provide a readme for it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ bin/python:
 	$(PYTHON) -m venv .
 	bin/pip install --upgrade pip
 
-bin/hatch: bin/python
-	bin/pip install hatch
+bin/hatch: dev
 
+bin/twine: dev
 
 dev: bin/python
 	bin/pip install -r requirements.txt
@@ -26,8 +26,14 @@ generate: bin/python dev
 install: bin/python dev
 	bin/pip install -e .
 
-build: install bin/hatch
+build: install bin/hatch bin/twine
 	bin/hatch build
+
+test-release: build
+	bin/twine upload -r testpypi dist/*
+
+release: clean build
+	bin/twine upload dist/*
 
 lint: dev
 	bin/mypy -p elastic_agent_client
@@ -42,4 +48,4 @@ test: dev install
 	bin/pytest --cov-config=pyproject.toml --cov=. --fail-slow=$(SLOW_TEST_THRESHOLD) -sv tests
 
 clean:
-	rm -rf bin lib include .proto
+	rm -rf bin lib include .proto dist

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,7 @@
+# Publishing a package to pypi
+
+## Versioning strategy
+
+## Getting credentials
+
+## Actually publishing

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,7 +1,25 @@
 # Publishing a package to pypi
 
+This guide explains how to publish the package into PyPi: https://pypi.org/project/elastic-agent-client/.
+
 ## Versioning strategy
+
+For now we'll stick with a simple strategy of having `0.1.0` release and then bump patch versions: `0.1.1`, `0.1.2`, `0.1.3` and so on. Once we feel package is ready for proper public release we will choose a versioning strategy similar to other Elastic products and will stick to it.
 
 ## Getting credentials
 
+You will need `vault` CLI tools installed or have access to a web version. You need to have permissions to access the keys - if you don't please reach out to the team lead.
+
+Secrets for publishing to live PyPi are in `ent-search-team/pypi-ent-search-dev`, secrets for publishing to test version are in `ent-search-team/test-pypi-ent-search-dev`.
+
 ## Actually publishing
+
+1. First make sure that the version of the package (see https://github.com/elastic/python-elastic-agent-client/blob/main/elastic_agent_client/version.py) is correct and is the desired version number
+2. Verify that all linting and tests pass: `make lint test`
+3. Verify that protobuf files are up-to-date: `make generate` and then `git diff` to see the changes. If any changes are present, first merge them into the branch published before continuing
+4. Do a test publish: `make test-release`. When prompted for an api key, insert a key from running this command: `vault read -field publishing-api-key secret/ent-search-team/test-pypi-ent-search-dev`
+5. Check the package on https://test.pypi.org/project/elastic-agent-client - check readme, version, other things that you consider important
+6. Do a prod publish: `make release`. When prompted for an api key, insert a key from running this command: `vault read -field publishing-api-key secret/ent-search-team/pypi-ent-search-dev`
+7. Check the package on https://pypi.org/project/elastic-agent-client - check readme, version, other things that you consider important
+8. Bump version in the version file: https://github.com/elastic/python-elastic-agent-client/blob/main/elastic_agent_client/version.py
+9. Done!

--- a/README.md
+++ b/README.md
@@ -86,12 +86,6 @@ Instead, when `make generate` runs, it will:
 
 ### TODO List
 - [ ] remove all inline TODOs
-- [ ] write tests
-- [ ] use ECS logging
-- [ ] add NOTICE file
-- [ ] push to pypi
-- [ ] open source
-- [ ] record a demo
 - [ ] write a blog
 - [ ] one day...
   - [ ] support "custom actions" to trigger a sync, test connection, etc

--- a/elastic_agent_client/version.py
+++ b/elastic_agent_client/version.py
@@ -1,0 +1,7 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+__version__ = "0.0.1.dev1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [project]
 name = "elastic_agent_client"
-version = "0.0.1.dev1"
 description = "A python implementation of an Elastic Agent Client"
 url = "https://github.com/elastic/python-elastic-agent-client"
 readme = "README.md"
@@ -77,6 +76,9 @@ show_missing=true
 [tool.hatch.build]
 dev-mode-dirs = ["."]
 directory="dist"
+
+[tool.hatch.version]
+path = "elastic_agent_client/version.py"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "License :: Other/Proprietary License"
 ]
+dynamic = ["version"]
 
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "elastic_agent_client"
-version = "0.0.1"
+version = "0.0.1.dev1"
 description = "A python implementation of an Elastic Agent Client"
 url = "https://github.com/elastic/python-elastic-agent-client"
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ grpcio-tools==1.68.1
 protobuf==5.27.4
 uvloop==0.21.0
 elasticsearch[async]==8.16.0
+ecs-logging==2.2.0
+
 ruff==0.8.1
 pytest==8.3.4
 pytest-cov==6.0.0
@@ -13,4 +15,5 @@ pytest-fail-slow==0.6.0
 mypy==1.13.0
 types-protobuf==5.27.0.20240907
 pip-licenses==5.0.0
-ecs-logging==2.2.0
+hatch==1.13.0
+twine==5.1.1


### PR DESCRIPTION
See added readme file:

Now it's possible to easily publish the new version of elastic-agent-client to PyPi: https://pypi.org/project/elastic-agent-client.

It's possible to publish to a test PyPi too: https://test.pypi.org/project/elastic-agent-client/ - this allows us do some basic testing for the package before actually releasing it.

For now instructions are manual and pretty verbose, but in reality the process is trivial and most steps are _verifying_ that whatever is being published is safe to publish.