### PR TITLE
Use Buildkite_Branch env variable for github setup

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -12,7 +12,7 @@
         "dependabot[bot]",
         "renovate[bot]"
       ],
-      "build_on_commit": true,
+      "build_on_commit": false,
       "build_on_comment": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",

--- a/.buildkite/script/git-setup.sh
+++ b/.buildkite/script/git-setup.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 set -ex
 
-if [ -z "${GITHUB_PR_BRANCH+x}" ]; then
-  export GIT_BRANCH=${BUILDKITE_BRANCH}
-else
-  export GIT_BRANCH=${GITHUB_PR_BRANCH}
-fi
+export GIT_BRANCH=${GITHUB_PR_BRANCH:-BUILDKITE_BRANCH}
 
 git switch -
 git checkout $GIT_BRANCH

--- a/.buildkite/script/git-setup.sh
+++ b/.buildkite/script/git-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-export GIT_BRANCH=${GITHUB_PR_BRANCH:-BUILDKITE_BRANCH}
+export GIT_BRANCH=${GITHUB_PR_BRANCH:-$BUILDKITE_BRANCH}
 
 git switch -
 git checkout $GIT_BRANCH

--- a/.buildkite/script/git-setup.sh
+++ b/.buildkite/script/git-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-if [ -z "${GITHUB_PR_BRANCH}" ]; then
+if [ -z "${GITHUB_PR_BRANCH+x}" ]; then
   export GIT_BRANCH=${BUILDKITE_BRANCH}
 else
   export GIT_BRANCH=${GITHUB_PR_BRANCH}

--- a/.buildkite/script/git-setup.sh
+++ b/.buildkite/script/git-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-export GIT_BRANCH=${GITHUB_PR_BRANCH}
+export GIT_BRANCH=${BUILDKITE_BRANCH}
 
 git switch -
 git checkout $GIT_BRANCH

--- a/.buildkite/script/git-setup.sh
+++ b/.buildkite/script/git-setup.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -ex
 
-export GIT_BRANCH=${BUILDKITE_BRANCH}
+if [ -z "${GITHUB_PR_BRANCH}" ]; then
+  export GIT_BRANCH=${BUILDKITE_BRANCH}
+else
+  export GIT_BRANCH=${GITHUB_PR_BRANCH}
+fi
 
 git switch -
 git checkout $GIT_BRANCH

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -23,6 +23,8 @@ spec:
     spec:
       repository: elastic/python-elastic-agent-client
       pipeline_file: ".buildkite/pipeline.yml"
+      provider_settings:
+        skip_pull_request_builds_for_existing_commits: false
       teams:
         search-extract-and-transform:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
Set `build_on_commit` and `skip_pull_request_builds_for_existing_commits` to false based on this [issue](https://github.com/elastic/connectors/pull/2276) I found which I _think_ should eliminate the separate builds. 