### PR TITLE
Bumping version for a release of 0.0.1dev2

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -664,7 +664,7 @@ support library is itself covered by the above license.
 
 
 types-protobuf
-5.27.0.20240907
+5.28.0.20240924
 Apache Software License
 UNKNOWN
 

--- a/elastic_agent_client/version.py
+++ b/elastic_agent_client/version.py
@@ -4,4 +4,4 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 
-__version__ = "0.0.1.dev1"
+__version__ = "0.0.1.dev2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ protobuf==5.28.1
 uvloop==0.21.0
 elasticsearch[async]==8.17.0
 ecs-logging==2.2.0
-types-protobuf==5.28.0.20240924
+types-protobuf==5.28.3.20241203
 
 # dev
 ruff==0.8.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ protobuf==5.28.1
 uvloop==0.21.0
 elasticsearch[async]==8.17.0
 ecs-logging==2.2.0
+types-protobuf==5.28.0.20240924
 
+# dev
 ruff==0.8.6
 pytest==8.3.4
 pytest-cov==6.0.0
@@ -13,7 +15,6 @@ pytest-mock==3.14.0
 pytest-randomly==3.16.0
 pytest-fail-slow==0.6.0
 mypy==1.14.1
-types-protobuf==5.27.0.20240907
 pip-licenses==5.0.0
 hatch==1.14.0
 twine==6.0.1


### PR DESCRIPTION
Planning to release 0.0.1dev2.

Saw dependency update for grpcio [here](https://github.com/elastic/connectors/pull/3134/files) and this is incorrect - everything breaks on incorrect versions of grpcio - this has a potential to break our docker images.