### PR TITLE
Run renovate only on weekends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "local>elastic/renovate-config"
   ],
+  "schedule": [
+    "* * * * 0,6"
+  ],
   "ignoreDeps": [
     "protobuf",
     "types-protobuf"


### PR DESCRIPTION
See https://elastic.slack.com/archives/C01795T48LQ/p1743165270846379:

Renovate sending updates every day makes the routine harder to handle. I feel it's great to batch it during weekends, and then resolve all on Monday/Tuesday.