### PR TITLE
Bump to 0.0.2

### DIFF
--- a/elastic_agent_client/version.py
+++ b/elastic_agent_client/version.py
@@ -4,4 +4,4 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 
-__version__ = "0.0.1.dev2"
+__version__ = "0.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "pytest-fail-slow==0.6.0",
     "mypy==1.18.2",
     "pip-licenses==5.0.0",
-    "hatch==1.16.2",
+    "hatch==1.17.1",
     "twine==6.2.0",
 ]
 


### PR DESCRIPTION
Bumping version to 0.0.2. Along the way upgraded `hatch` because it was incompatible with latest python virtualenv:

```
Environment `hatch-build` is incompatible: module 'virtualenv.discovery.builtin' has no attribute 'propose_interpreters'
```